### PR TITLE
fix recent project64 builds

### DIFF
--- a/SM64O/IEmulatorAccessor.cs
+++ b/SM64O/IEmulatorAccessor.cs
@@ -3,10 +3,10 @@ namespace SM64O
     public interface IEmulatorAccessor
     {
         bool Attached { get; }
-        int BaseAddress { get; }
+        uint BaseAddress { get; }
         int MainModuleAddress { get; }
         string WindowName { get; }
-        void Open(string processName, int step = 1024);
+        void Open(string processName, uint step = 1024);
         int WriteMemory(int offset, byte[] buffer, int bufferLength);
         int ReadMemory(int offset, byte[] buffer, int bufferLength);
 

--- a/SM64O/ReadWritingMemory.cs
+++ b/SM64O/ReadWritingMemory.cs
@@ -16,20 +16,28 @@ namespace SM64O
     {
         [DllImport("kernel32", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern int OpenProcess(int dwDesiredAccess, int bInheritHandle, int dwProcessId);
-        [DllImport("kernel32", EntryPoint = "WriteProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
 
+        [DllImport("kernel32", EntryPoint = "WriteProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern int WriteProcessMemory1(int hProcess, int lpBaseAddress, ref int lpBuffer, int nSize, ref int lpNumberOfBytesWritten);
+
         [DllImport("kernel32", EntryPoint = "WriteProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern float WriteProcessMemory2(int hProcess, int lpBaseAddress, ref float lpBuffer, int nSize, ref int lpNumberOfBytesWritten);
+
         [DllImport("kernel32", EntryPoint = "WriteProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern long WriteProcessMemory3(int hProcess, int lpBaseAddress, ref long lpBuffer, int nSize, ref int lpNumberOfBytesWritten);
-        [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
 
+        [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern int ReadProcessMemory1(int hProcess, int lpBaseAddress, ref int lpBuffer, int nSize, ref int lpNumberOfBytesRead);
+
+        [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
+        private static extern int ReadProcessMemory1(int hProcess, uint lpBaseAddress, ref int lpBuffer, int nSize, ref int lpNumberOfBytesRead);
+
         [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern float ReadProcessMemory2(int hProcess, int lpBaseAddress, ref float lpBuffer, int nSize, ref int lpNumberOfBytesRead);
+
         [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern long ReadProcessMemory3(int hProcess, int lpBaseAddress, ref long lpBuffer, int nSize, ref int lpNumberOfBytesRead);
+
         [DllImport("kernel32", EntryPoint = "ReadProcessMemory", CharSet = CharSet.Ansi, SetLastError = true, ExactSpelling = true)]
         private static extern byte[] ReadProcessMemory4(int hProcess, int lpBaseAddress, byte[] lpBuffer, int iSize, ref int lpNumberOfBytesRead);
 
@@ -354,7 +362,7 @@ namespace SM64O
             return vBuffer;
         }
 
-        public static int GetBaseAddress(string ProcessName, int scanStep = 0x1000, int nsize = 4)
+        public static uint GetBaseAddress(string ProcessName, uint scanStep = 0x1000, int nsize = 4)
         {
             if (ProcessName.EndsWith(".exe"))
             {
@@ -374,9 +382,9 @@ namespace SM64O
             }
 
             int vBuffer = 0;
-            int startPoint = 0x00000000;
+            uint startPoint = 0x00000000;
             
-            for (int x = startPoint; x <= 0x72D00000; x += scanStep)
+            for (uint x = startPoint; x <= 0xFFFE0000; x += scanStep)
             {
                 //Label1.Text = "Currently processing address: " & x
 

--- a/SM64O/WindowsEmulatorAccessor.cs
+++ b/SM64O/WindowsEmulatorAccessor.cs
@@ -12,17 +12,23 @@ namespace SM64O
         [DllImport("kernel32.dll")]
         public static extern bool ReadProcessMemory(int hProcess, int lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesRead);
 
+        [DllImport("kernel32.dll")]
+        public static extern bool ReadProcessMemory(int hProcess, uint lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesRead);
+
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern bool WriteProcessMemory(int hProcess, int lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesWritten);
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static extern bool WriteProcessMemory(int hProcess, uint lpBaseAddress, byte[] lpBuffer, int dwSize, ref int lpNumberOfBytesWritten);
+
         const int PROCESS_WM_READ = 0x0010;
 
-        private int baseAddress;
+        private uint baseAddress;
         private IntPtr processHandle;
         private Process process;
         private int mainModuleAdd;
 
-        public int BaseAddress
+        public uint BaseAddress
         {
             get { return baseAddress; }
         }
@@ -47,7 +53,7 @@ namespace SM64O
             }
         }
 
-        public void Open(string processName, int step = 1024)
+        public void Open(string processName, uint step = 1024)
         {
             process = Process.GetProcessesByName(processName)[0];
 
@@ -62,15 +68,19 @@ namespace SM64O
 
         public int WriteMemory(int offset, byte[] buffer, int bufferLength)
         {
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException();
             int bytesWritten = 0;
-            WriteProcessMemory((int)processHandle, baseAddress + offset, buffer, bufferLength, ref bytesWritten);
+            WriteProcessMemory((int)processHandle, baseAddress + (uint)offset, buffer, bufferLength, ref bytesWritten);
             return bytesWritten;
         }
 
         public int ReadMemory(int offset, byte[] buffer, int bufferLength)
         {
+            if (offset < 0)
+                throw new ArgumentOutOfRangeException();
             int bytesRead = 0;
-            ReadProcessMemory((int)processHandle, baseAddress + offset, buffer, bufferLength, ref bytesRead);
+            ReadProcessMemory((int)processHandle, baseAddress + (uint)offset, buffer, bufferLength, ref bytesRead);
             return bytesRead;
         }
 


### PR DESCRIPTION
Recent builds are compiled with `/LARGEADDRESSAWARE` meaning it is possible for the N64 RAM to be located at an address higher than `0x72D00000`. For me it is working on the latest nightly build of Project64:

![](https://i.imgur.com/A0lm21B.png)